### PR TITLE
- fix BiomeProvider falling back to deep ocean biomes instead of land…

### DIFF
--- a/src/main/java/com/terraforged/feature/template/decorator/tree/TreeFeatureDecorator.java
+++ b/src/main/java/com/terraforged/feature/template/decorator/tree/TreeFeatureDecorator.java
@@ -40,6 +40,11 @@ public class TreeFeatureDecorator implements Decorator<TreeBuffer> {
 
     @Override
     public void apply(TreeBuffer world, Random random) {
+        // don't decorate if no logs/leaves were placed!
+        if (world.getLogs().isEmpty() || world.getLeaves().isEmpty()) {
+            return;
+        }
+
         decorator.func_225576_a_(
                 world.getDelegate(),
                 random,


### PR DESCRIPTION
… (caused deep oceans to sometimes appear in rivers)

- fix strata layers not generating deterministically
- fix oob exception when attempting to decorate a tree which had no leaves/logs place
- fix for vanilla sand being placed over modded sand